### PR TITLE
Update tests for HIP_NO_HALF, and handle __HIP_NO_HALF_CONVERSIONS__ …

### DIFF
--- a/library/include/rocwmma/internal/config.hpp
+++ b/library/include/rocwmma/internal/config.hpp
@@ -137,6 +137,18 @@ namespace rocwmma
 #define ROCWMMA_UNSUPPORTED_IMPL(MSG) __attribute__((deprecated(MSG)))
 #endif
 
+#if defined(HIP_NO_HALF)
+#define ROCWMMA_NO_HALF 1
+#else
+#define ROCWMMA_NO_HALF 0
+#endif // HIP_NO_HALF
+
+#if ROCWMMA_NO_HALF || (!ROCWMMA_NO_HALF && defined(__HIP_NO_HALF_CONVERSIONS__))
+#define ROCWMMA_TESTS_NO_HALF 1
+#else
+#define ROCWMMA_TESTS_NO_HALF 0
+#endif // !ROCWMMA_NO_HALF && defined(__HIP_NO_HALF_CONVERSIONS__)
+
 ///
 /// Sanity checks
 ///

--- a/library/include/rocwmma/internal/convert.hpp
+++ b/library/include/rocwmma/internal/convert.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -62,6 +62,7 @@ namespace rocwmma
             }
         };
 
+#if !ROCWMMA_NO_HALF
         template <>
         struct amdgcn_convert<hfloat16_t, float32_t>
         {
@@ -97,6 +98,8 @@ namespace rocwmma
                 return result;
             }
         };
+
+#endif // !ROCWMMA_NO_HALF
 
     } // namespace detail
 

--- a/library/include/rocwmma/internal/mfma_impl.hpp
+++ b/library/include/rocwmma/internal/mfma_impl.hpp
@@ -175,6 +175,7 @@ namespace rocwmma
             }
         };
 
+#if !ROCWMMA_NO_HALF
         template <>
         struct amdgcn_mfma<hfloat16_t, float32_t, 16, 16>
             : public amdgcn_mfma<float16_t, float32_t, 16, 16>
@@ -198,6 +199,7 @@ namespace rocwmma
             : public amdgcn_mfma<float16_t, float16_t, 32, 32>
         {
         };
+#endif // !ROCWMMA_NO_HALF
 
 #if !ROCWMMA_ARCH_GFX908
 

--- a/library/include/rocwmma/internal/pack_util_impl.hpp
+++ b/library/include/rocwmma/internal/pack_util_impl.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -140,6 +140,7 @@ namespace rocwmma
         using PackedT   = float32_t;
     };
 
+#if !ROCWMMA_NO_HALF
     template <>
     struct PackTraits<hfloat16_t>
     {
@@ -151,6 +152,7 @@ namespace rocwmma
         using UnpackedT = hfloat16_t;
         using PackedT   = float32_t;
     };
+#endif // !ROCWMMA_NO_HALF
 
     template <>
     struct PackTraits<bfloat16_t>

--- a/library/include/rocwmma/internal/type_traits.hpp
+++ b/library/include/rocwmma/internal/type_traits.hpp
@@ -36,7 +36,7 @@
 #define FLT_EPSILON __FLT_EPSILON__
 #define FLT_MAX __FLT_MAX__
 #define FLT_MIN __FLT_MIN__
-#define HUGE_VALF (__builtin_huge_valf ())
+#define HUGE_VALF (__builtin_huge_valf())
 
 #endif // !defined(__HIPCC_RTC__)
 
@@ -72,9 +72,11 @@ namespace rocwmma
         {
             union
             {
-                uint16_t   i16;
-                float16_t  f16;
+                uint16_t  i16;
+                float16_t f16;
+#if !ROCWMMA_NO_HALF
                 hfloat16_t h16;
+#endif // !ROCWMMA_NO_HALF
                 bfloat16_t b16;
             };
             constexpr Fp16Bits(uint16_t initVal)
@@ -85,10 +87,12 @@ namespace rocwmma
                 : f16(initVal)
             {
             }
+#if !ROCWMMA_NO_HALF
             constexpr Fp16Bits(hfloat16_t initVal)
                 : h16(initVal)
             {
             }
+#endif
             constexpr Fp16Bits(bfloat16_t initVal)
                 : b16(initVal)
             {
@@ -648,7 +652,7 @@ namespace std
     ///////////////////////////////////////////////////////////
     ///////////  std::numeric_limits<hfloat16_t>  /////////////
     ///////////////////////////////////////////////////////////
-
+#if !ROCWMMA_NO_HALF
     template <>
     ROCWMMA_HOST_DEVICE constexpr rocwmma::hfloat16_t
         numeric_limits<rocwmma::hfloat16_t>::epsilon() noexcept
@@ -704,6 +708,8 @@ namespace std
         rocwmma::detail::Fp16Bits eps(static_cast<uint16_t>(0x7DFF));
         return eps.h16;
     }
+
+#endif // !ROCWMMA_NO_HALF
 
     ///////////////////////////////////////////////////////////
     ///////////  std::numeric_limits<bfloat16_t>  /////////////
@@ -851,9 +857,12 @@ namespace rocwmma
     }
 
     template <typename T,
-              typename std::enable_if_t<std::is_same<T, hfloat16_t>::value
-                                            || std::is_same<T, float16_t>::value,
-                                        int>
+              typename std::enable_if_t<
+#if !ROCWMMA_NO_HALF
+                  std::is_same<T, hfloat16_t>::value ||
+#endif // !ROCWMMA_NO_HALF
+                      std::is_same<T, float16_t>::value,
+                  int>
               = 0>
     constexpr auto maxExactInteger() -> int32_t
     {

--- a/library/include/rocwmma/internal/types.hpp
+++ b/library/include/rocwmma/internal/types.hpp
@@ -99,7 +99,10 @@ namespace rocwmma
 
     // Non-native types
     using bfloat16_t = hip_bfloat16;
+
+#if !ROCWMMA_NO_HALF
     using hfloat16_t = __half;
+#endif // !ROCWMMA_NO_HALF
 
     using bfloat8_t = rocwmma_bf8;
     using float8_t  = rocwmma_f8;

--- a/library/include/rocwmma/internal/types_ext.hpp
+++ b/library/include/rocwmma/internal/types_ext.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -43,42 +43,65 @@ namespace rocwmma
 
 #if !defined(__HIPCC_RTC__)
 
-    ///////////////////////////////////////////////////////////
-    ///////////  rocwmma::hfloat16_t host conversions  //////////
-    ///////////////////////////////////////////////////////////
-    template<typename Incoming, typename Outgoing , typename std::enable_if_t<!std::is_same<Incoming, hfloat16_t>::value && !std::is_same<Outgoing, hfloat16_t>::value, int> = 0>
+    ////////////////////////////////////////////////////////////////////////
+    ///////////  rocwmma::hfloat16_t host and device conversions  //////////
+    ////////////////////////////////////////////////////////////////////////
+    template <typename Outgoing,
+              typename Incoming,
+              typename std::enable_if_t<!std::is_same_v<Incoming, Outgoing>, int> = 0>
     __host__ __device__ inline Outgoing convert(const Incoming& value)
     {
-        return static_cast<Outgoing>(value);
-    }
+#if !ROCWMMA_NO_HALF
+        if constexpr(std::is_same_v<Outgoing, hfloat16_t>)
+        {
 
-    template<typename Incoming, typename Outgoing, typename std::enable_if_t<std::is_same<Outgoing, hfloat16_t>::value, int> = 0>
-    __host__ __device__ inline hfloat16_t convert(const Incoming& value)
-    {
 #if defined(__HIP_NO_HALF_CONVERSIONS__)
-        detail::Fp16Bits fp16(static_cast<float16_t>(value));
-        return fp16.h16;
+            detail::Fp16Bits fp16(static_cast<float16_t>(value));
+            return fp16.h16;
 #else
-        return static_cast<hfloat16_t>(value);
-#endif
-    }
+            return static_cast<hfloat16_t>(value);
+#endif // defined(__HIP_NO_HALF_CONVERSIONS__)
+        }
+        else if constexpr(std::is_same_v<Incoming, hfloat16_t>)
+        {
 
-    template<typename Incoming, typename Outgoing, typename std::enable_if_t<std::is_same<Incoming, hfloat16_t>::value, int> = 0>
-    __host__ __device__ inline Outgoing convert(const hfloat16_t& value)
-    {
 #if defined(__HIP_NO_HALF_CONVERSIONS__)
-        detail::Fp16Bits fp16(value);
-        return convert<float16_t, Outgoing>(fp16.f16);
+            detail::Fp16Bits fp16(value);
+            return static_cast<Outgoing>(fp16.f16);
 #else
-        return static_cast<Outgoing>(value);
-#endif
+            return static_cast<Outgoing>(value);
+#endif // defined(__HIP_NO_HALF_CONVERSIONS__)
+        }
+        else
+#endif // !ROCWMMA_NO_HALF
+        {
+            return static_cast<Outgoing>(value);
+        }
     }
 
-    ///////////////////////////////////////////////////////////
-    ///////////  rocwmma::hfloat16_t host operators  //////////
-    ///////////////////////////////////////////////////////////
+    template <typename Outgoing,
+              typename Incoming,
+              typename std::enable_if_t<std::is_same_v<Incoming, Outgoing>, int> = 0>
+    __host__ __device__ inline Outgoing const& convert(const Incoming& value)
+    {
+        return value;
+    }
 
-    __host__ inline bool operator==(const hfloat16_t& x, const hfloat16_t& y)
+    ////////////////////////////////////////////////////////////////////
+    ///////////  rocwmma::hfloat16_t host & device operators  //////////
+    ///////////////////////////////////////////////////////////////////
+
+#if defined(__HIP_NO_HALF_OPERATORS__)
+// No operators defined for host or device
+#define ROCWMMA_HALF_OP_ATTR ROCWMMA_HOST_DEVICE
+#else
+// No operators defined just for host
+#define ROCWMMA_HALF_OP_ATTR ROCWMMA_HOST
+#endif // defined(__HIP_NO_HALF_OPERATORS__)
+
+#if !ROCWMMA_NO_HALF
+
+    ROCWMMA_HALF_OP_ATTR inline bool operator==(const hfloat16_t& x, const hfloat16_t& y)
     {
         auto absDiff = std::fabs(__half2float(x) - __half2float(y));
         auto absAdd  = std::fabs(__half2float(x) + __half2float(y));
@@ -86,97 +109,59 @@ namespace rocwmma
                || absDiff < __half2float(std::numeric_limits<hfloat16_t>::min());
     }
 
-    __host__ inline bool operator!=(const hfloat16_t& x, const hfloat16_t& y)
+    ROCWMMA_HALF_OP_ATTR inline bool operator!=(const hfloat16_t& x, const hfloat16_t& y)
     {
         return !(x == y);
     }
 
-    __host__ inline hfloat16_t operator-(const hfloat16_t& x)
+    ROCWMMA_HALF_OP_ATTR inline hfloat16_t operator-(const hfloat16_t& x)
     {
         detail::Fp16Bits fp16(x);
         fp16.i16 ^= 0x8000; // Flip sign
         return fp16.h16;
     }
 
-    __host__ inline hfloat16_t operator+(const hfloat16_t& x, const hfloat16_t& y)
+    ROCWMMA_HALF_OP_ATTR inline hfloat16_t operator+(const hfloat16_t& x, const hfloat16_t& y)
     {
-#if !defined(__HIP_NO_HALF_OPERATORS__)
-        return static_cast<hfloat16_t>(static_cast<float16_t>(x) + static_cast<float16_t>(y));
-#else
-        float16_t fp16_xy = (*(float16_t *)(&x)) + (*(float16_t *)(&y));
-        detail::Fp16Bits fp16(fp16_xy);
-        return fp16.h16;
-#endif
+        return convert<hfloat16_t>(convert<float16_t>(x) + convert<float16_t>(y));
     }
 
-    __host__ inline hfloat16_t operator-(const hfloat16_t& x, const hfloat16_t& y)
+    ROCWMMA_HALF_OP_ATTR inline hfloat16_t operator-(const hfloat16_t& x, const hfloat16_t& y)
     {
-#if !defined(__HIP_NO_HALF_OPERATORS__)
-        return static_cast<hfloat16_t>(static_cast<float16_t>(x) - static_cast<float16_t>(y));
-#else
-        float16_t fp16_xy = (*(float16_t *)(&x)) - (*(float16_t *)(&y));
-        detail::Fp16Bits fp16(fp16_xy);
-        return fp16.h16;
-#endif
+        return convert<hfloat16_t>(convert<float16_t>(x) - convert<float16_t>(y));
     }
 
-    __host__ inline hfloat16_t operator*(const hfloat16_t& x, const hfloat16_t& y)
+    ROCWMMA_HALF_OP_ATTR inline hfloat16_t operator*(const hfloat16_t& x, const hfloat16_t& y)
     {
-#if !defined(__HIP_NO_HALF_OPERATORS__)
-        return static_cast<hfloat16_t>(static_cast<float16_t>(x) * static_cast<float16_t>(y));
-#else
-        float16_t fp16_xy = (*(float16_t *)(&x)) * (*(float16_t *)(&y));
-        detail::Fp16Bits fp16(fp16_xy);
-        return fp16.h16;
-#endif
+        return convert<hfloat16_t>(convert<float16_t>(x) * convert<float16_t>(y));
     }
 
-    __host__ inline hfloat16_t operator/(const hfloat16_t& x, const hfloat16_t& y)
+    ROCWMMA_HALF_OP_ATTR inline hfloat16_t operator/(const hfloat16_t& x, const hfloat16_t& y)
     {
-#if !defined(__HIP_NO_HALF_OPERATORS__)
-        return static_cast<hfloat16_t>(static_cast<float16_t>(x) / static_cast<float16_t>(y));
-#else
-        float16_t fp16_xy = (*(float16_t *)(&x)) / (*(float16_t *)(&y));
-        detail::Fp16Bits fp16(fp16_xy);
-        return fp16.h16;
-#endif
+        return convert<hfloat16_t>(convert<float16_t>(x) / convert<float16_t>(y));
     }
 
-    __host__ inline hfloat16_t& operator+=(hfloat16_t& x, const hfloat16_t& y)
+    ROCWMMA_HALF_OP_ATTR inline hfloat16_t& operator+=(hfloat16_t& x, const hfloat16_t& y)
     {
-#if !defined(__HIP_NO_HALF_OPERATORS__)
-        return x = static_cast<hfloat16_t>(static_cast<float16_t>(x) + static_cast<float16_t>(y));
-#else
         return x = x + y;
-#endif
     }
 
-    __host__ inline hfloat16_t& operator-=(hfloat16_t& x, const hfloat16_t& y)
+    ROCWMMA_HALF_OP_ATTR inline hfloat16_t& operator-=(hfloat16_t& x, const hfloat16_t& y)
     {
-#if !defined(__HIP_NO_HALF_OPERATORS__)
-        return x = static_cast<hfloat16_t>(static_cast<float16_t>(x) - static_cast<float16_t>(y));
-#else
         return x = x - y;
-#endif
     }
 
-    __host__ inline hfloat16_t& operator*=(hfloat16_t& x, const hfloat16_t& y)
+    ROCWMMA_HALF_OP_ATTR inline hfloat16_t& operator*=(hfloat16_t& x, const hfloat16_t& y)
     {
-#if !defined(__HIP_NO_HALF_OPERATORS__)
-        return x = static_cast<hfloat16_t>(static_cast<float16_t>(x) * static_cast<float16_t>(y));
-#else
         return x = x * y;
-#endif
     }
 
-    __host__ inline hfloat16_t& operator/=(hfloat16_t& x, const hfloat16_t& y)
+    ROCWMMA_HALF_OP_ATTR inline hfloat16_t& operator/=(hfloat16_t& x, const hfloat16_t& y)
     {
-#if !defined(__HIP_NO_HALF_OPERATORS__)
-        return x = static_cast<hfloat16_t>(static_cast<float16_t>(x) / static_cast<float16_t>(y));
-#else
         return x = x / y;
-#endif
     }
+
+#endif // !ROCWMMA_NO_HALF
 
 #endif // !defined(__HIPCC_RTC__)
 
@@ -197,12 +182,14 @@ namespace std
     ///////////////////////////////////////////////////////////
     //////////  std::ostream::operator<<(hfloat16_t)  /////////
     ///////////////////////////////////////////////////////////
-
+#if !ROCWMMA_NO_HALF
     inline ostream& operator<<(ostream& stream, rocwmma::hfloat16_t const& val)
     {
         return stream << __half2float(val);
     }
-#endif // !defined(__HIPCC_RTC__)
+#endif // !ROCWMMA_NO_HALF
+
+#endif // !defined(__HIPCC_RTC__) && !ROCWMMA_NO_HALF
 
 } // namespace std
 

--- a/library/include/rocwmma/internal/utils.hpp
+++ b/library/include/rocwmma/internal/utils.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -414,11 +414,13 @@ namespace rocwmma
         return "f16";
     }
 
+#if !ROCWMMA_NO_HALF
     template <>
     constexpr const char* dataTypeToString<hfloat16_t>()
     {
         return "h16";
     }
+#endif // !ROCWMMA_NO_HALF
 
     template <>
     constexpr const char* dataTypeToString<bfloat16_t>()

--- a/library/include/rocwmma/internal/vector.hpp
+++ b/library/include/rocwmma/internal/vector.hpp
@@ -317,6 +317,7 @@ ROCWMMA_REGISTER_HIP_NATIVE_VECTOR_TYPE(rocwmma::uint64_t, 512);
 
 // HIP doesn't have functional support for non-native vector types __half or bfloat16_t.
 // Implement full support for those here.
+#if !ROCWMMA_NO_HALF
 ROCWMMA_REGISTER_HIP_NON_NATIVE_VECTOR_TYPE(rocwmma::hfloat16_t, 1);
 ROCWMMA_REGISTER_HIP_NON_NATIVE_VECTOR_TYPE(rocwmma::hfloat16_t, 2);
 ROCWMMA_REGISTER_HIP_NON_NATIVE_VECTOR_TYPE(rocwmma::hfloat16_t, 3);
@@ -328,6 +329,7 @@ ROCWMMA_REGISTER_HIP_NON_NATIVE_VECTOR_TYPE(rocwmma::hfloat16_t, 64);
 ROCWMMA_REGISTER_HIP_NON_NATIVE_VECTOR_TYPE(rocwmma::hfloat16_t, 128);
 ROCWMMA_REGISTER_HIP_NON_NATIVE_VECTOR_TYPE(rocwmma::hfloat16_t, 256);
 ROCWMMA_REGISTER_HIP_NON_NATIVE_VECTOR_TYPE(rocwmma::hfloat16_t, 512);
+#endif // !ROCWMMA_NO_HALF
 
 // Register bfloat8_t vector types
 ROCWMMA_REGISTER_HIP_NON_NATIVE_VECTOR_TYPE_WITH_INC_DEC_OPS_AS_FLOAT(rocwmma::bfloat8_t, 1);

--- a/samples/common.hpp
+++ b/samples/common.hpp
@@ -32,32 +32,34 @@
 
 // Helper macro for HIP errors
 #ifndef CHECK_HIP_ERROR
-#define CHECK_HIP_ERROR(status)                   \
-    if(status != hipSuccess)                      \
-    {                                             \
-        fprintf(stderr,                           \
-                "hip error: '%s'(%d) at %s:%d\n", \
-                hipGetErrorString(status),        \
-                status,                           \
-                __FILE__,                         \
-                __LINE__);                        \
-        exit(EXIT_FAILURE);                       \
+#define CHECK_HIP_ERROR(expression)                      \
+    if(auto status = (expression); status != hipSuccess) \
+    {                                                    \
+        fprintf(stderr,                                  \
+                "hip error: '%s'(%d) at %s:%d\n",        \
+                hipGetErrorString(status),               \
+                status,                                  \
+                __FILE__,                                \
+                __LINE__);                               \
+        exit(EXIT_FAILURE);                              \
     }
 #endif
 
 #ifndef CHECK_HIPRTC_ERROR
-#define CHECK_HIPRTC_ERROR(status)                   \
-    if(status != HIPRTC_SUCCESS)                     \
-    {                                                \
-        fprintf(stderr,                              \
-                "hipRTC error: '%s'(%d) at %s:%d\n", \
-                hiprtcGetErrorString(status),        \
-                status,                              \
-                __FILE__,                            \
-                __LINE__);                           \
-        exit(EXIT_FAILURE);                          \
+#define CHECK_HIPRTC_ERROR(expression)                       \
+    if(auto status = (expression); status != HIPRTC_SUCCESS) \
+    {                                                        \
+        fprintf(stderr,                                      \
+                "hipRTC error: '%s'(%d) at %s:%d\n",         \
+                hiprtcGetErrorString(status),                \
+                status,                                      \
+                __FILE__,                                    \
+                __LINE__);                                   \
+        exit(EXIT_FAILURE);                                  \
     }
 #endif
+
+#include <rocwmma/internal/type_traits.hpp>
 
 // HIP Host functions to determine the gfx architecture
 bool isGfx9()
@@ -113,23 +115,6 @@ bool isF32Supported()
 {
     return isGfx9();
 }
-
-struct Fp16Bits
-{
-    union
-    {
-        rocwmma::float16_t  f16;
-        rocwmma::hfloat16_t h16;
-    };
-    constexpr Fp16Bits(rocwmma::float16_t initVal)
-        : f16(initVal)
-    {
-    }
-    constexpr Fp16Bits(rocwmma::hfloat16_t initVal)
-        : h16(initVal)
-    {
-    }
-};
 
 inline double calculateGFlops(uint32_t m, uint32_t n, uint32_t k)
 {
@@ -192,11 +177,8 @@ __host__ static inline void
                 // Random values normalized such that output is between 0 and 1
                 auto value = __float2half(static_cast<float>(rand() / normalization)
                                           / static_cast<float>(RAND_MAX));
-#if !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
-                mat[t * batchOffset + i * k + j] = static_cast<DataT>(value);
-#else
-                mat[t * batchOffset + i * k + j] = static_cast<DataT>(Fp16Bits(value).f16);
-#endif // !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+
+                mat[t * batchOffset + i * k + j] = rocwmma::convert<DataT>(value);
             }
         }
     }

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,10 @@
 
 #ifndef ROCWMMA_TEST_COMMON_HPP
 #define ROCWMMA_TEST_COMMON_HPP
+
+#if ROCWMMA_TESTS_NO_HALF
+#warning("Building tests with hfloat16_t requires !HIP_NO_HALF && !__HIP_NO_HALF_CONVERSIONS__. Proceeding without hfloat16_t")
+#endif // !ROCWMMA_NO_HALF && __HIP_NO_HALF_CONVERSIONS__
 
 #include <iostream>
 #include <mutex>
@@ -53,18 +57,13 @@
 
 #ifdef ROCWMMA_BENCHMARK_TESTS
 #ifndef CHECK_RSMI_ERROR
-#define CHECK_RSMI_ERROR(expression, smiErrorFlag)                        \
-    if(auto status = (expression); status != RSMI_STATUS_SUCCESS)         \
-    {                                                                     \
-        const char* errName = nullptr;                                    \
-        rsmi_status_string(status, &errName);                             \
-        fprintf(stderr,                                                   \
-                "rsmi error: '%s'(%d) at %s:%d\n",                        \
-                errName,                                                  \
-                status,                                                   \
-                __FILE__,                                                 \
-                __LINE__);                                                \
-        smiErrorFlag = true;                                              \
+#define CHECK_RSMI_ERROR(expression, smiErrorFlag)                                               \
+    if(auto status = (expression); status != RSMI_STATUS_SUCCESS)                                \
+    {                                                                                            \
+        const char* errName = nullptr;                                                           \
+        rsmi_status_string(status, &errName);                                                    \
+        fprintf(stderr, "rsmi error: '%s'(%d) at %s:%d\n", errName, status, __FILE__, __LINE__); \
+        smiErrorFlag = true;                                                                     \
     }
 #endif
 #endif
@@ -325,8 +324,7 @@ namespace rocwmma
 
         // fill kernel wrapper for M x N matrix for mat[i] = i
         template <typename DataT>
-        __host__ static inline void
-            fillIdxLaunchKernel(DataT* d_mat, uint32_t m, uint32_t n)
+        __host__ static inline void fillIdxLaunchKernel(DataT* d_mat, uint32_t m, uint32_t n)
         {
             auto blockDim = dim3(1024, 1, 1);
             auto gridDim  = dim3(ceilDiv(m * n, blockDim.x), 1, 1);

--- a/test/dlrm/device/common.hpp
+++ b/test/dlrm/device/common.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,10 +32,12 @@
 namespace rocwmma
 {
 
+#if !ROCWMMA_TESTS_NO_HALF
     __device__ inline bool is_same(half a, half b)
     {
         return __heq(a, b);
     }
+#endif // !ROCWMMA_NO_HALF
 
     __device__ inline bool is_same(float a, float b)
     {

--- a/test/dlrm/dlrm_kernel_base_impl.hpp
+++ b/test/dlrm/dlrm_kernel_base_impl.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -112,12 +112,13 @@ namespace rocwmma
 
         // Datatypes
         auto isF64 = std::is_same<DataT, float64_t>::value;
+
+#if !ROCWMMA_TESTS_NO_HALF
+        auto isH16 = std::is_same<DataT, hfloat16_t>::value;
+#else
         auto isH16 = false;
-#if !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
-        isH16 = std::is_same<DataT, hfloat16_t>::value;
-#endif // !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
-        auto isF16
-            = std::is_same<DataT, float16_t>::value || isH16;
+#endif // !ROCWMMA_NO_HALF
+        auto isF16  = std::is_same<DataT, float16_t>::value || isH16;
         auto isBF16 = (std::is_same<DataT, bfloat16_t>::value);
         auto isI8   = (std::is_same<DataT, int8_t>::value);
 
@@ -402,17 +403,17 @@ namespace rocwmma
             CHECK_HIP_ERROR(hipEventElapsedTime(&timeMs, startEvent, stopEvent));
 
             // Calculate efficiency
-            auto& deviceInfo             = DeviceInfo::instance();
+            auto& deviceInfo = DeviceInfo::instance();
 
-            auto  devicePeakGFlopsPerSec  = deviceInfo->peakGFlopsPerSec<DataT>();
-            auto  outputSize = (passDirection == DlrmDirection_t::Forward) ? mM * mM : mM * mK;
+            auto devicePeakGFlopsPerSec = deviceInfo->peakGFlopsPerSec<DataT>();
+            auto outputSize = (passDirection == DlrmDirection_t::Forward) ? mM * mM : mM * mK;
 
             mElapsedTimeMs        = float64_t(timeMs);
             mTotalGFlops          = calculateGFlops(outputSize, mB, mK);
             mMeasuredTFlopsPerSec = calculateTFlopsPerSec(outputSize, mB, mK, mElapsedTimeMs)
                                     * static_cast<float64_t>(mRepeats);
 
-            mEfficiency = round(mMeasuredTFlopsPerSec / devicePeakGFlopsPerSec  * 100000.0);
+            mEfficiency = round(mMeasuredTFlopsPerSec / devicePeakGFlopsPerSec * 100000.0);
 
             CHECK_HIP_ERROR(hipEventDestroy(startEvent));
             CHECK_HIP_ERROR(hipEventDestroy(stopEvent));

--- a/test/gemm/gemm_common_test_params.hpp
+++ b/test/gemm/gemm_common_test_params.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -55,12 +55,10 @@ namespace rocwmma
             std::tuple<int8_t, int32_t, int32_t>>;
 
         // float8
-        using TestTypesF8 = std::tuple<
-            std::tuple<float8_t, float32_t, float32_t>>;
+        using TestTypesF8 = std::tuple<std::tuple<float8_t, float32_t, float32_t>>;
 
         // bfloat8
-        using TestTypesBF8 = std::tuple<
-            std::tuple<bfloat8_t, float32_t, float32_t>>;
+        using TestTypesBF8 = std::tuple<std::tuple<bfloat8_t, float32_t, float32_t>>;
 
         // Non-native bfloat16_t
         using TestTypesBF16 = std::tuple<
@@ -78,7 +76,7 @@ namespace rocwmma
 #endif // ROCWMMA_EXTENDED_TESTS
             std::tuple<float16_t, float32_t, float32_t>>;
 
-#if !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#if !ROCWMMA_TESTS_NO_HALF
         // Non-native hfloat16_t (i.e. __half)
         using TestTypesH16 = std::tuple<
 #if defined(ROCWMMA_EXTENDED_TESTS)
@@ -86,7 +84,7 @@ namespace rocwmma
             std::tuple<hfloat16_t, hfloat16_t, float32_t>,
 #endif // ROCWMMA_EXTENDED_TESTS
             std::tuple<hfloat16_t, float32_t, float32_t>>;
-#endif // !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#endif // !ROCWMMA_TESTS_NO_HALF
 
         // Native single f32
         using TestTypesF32 = std::tuple<std::tuple<float32_t, float32_t, float32_t>>;
@@ -100,18 +98,19 @@ namespace rocwmma
         // Aggregate types <= 8 bit
         using TestTypesTiny = typename Concat<TestTypesF8, TestTypesBF8, TestTypesI8>::Result;
 
-#if !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
         // Aggregate types <= 16 bit
-        using TestTypesSmall =
-            typename Concat<TestTypesTiny, TestTypesBF16, TestTypesF16, TestTypesH16>::Result;
-#else
-        // Aggregate types <= 16 bit
-        using TestTypesSmall =
-            typename Concat<TestTypesTiny, TestTypesBF16, TestTypesF16>::Result;
-#endif // !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+        using TestTypesSmall = typename Concat<TestTypesTiny,
+                                               TestTypesBF16,
+                                               TestTypesF16
+#if !ROCWMMA_TESTS_NO_HALF
+                                               ,
+                                               TestTypesH16
+#endif // !ROCWMMA_TESTS_NO_HALF
+                                               >::Result;
 
         // Aggregate types <= 32 bit
-        using TestTypesMedium = typename Concat<TestTypesSmall, TestTypesF32, TestTypesXF32>::Result;
+        using TestTypesMedium =
+            typename Concat<TestTypesSmall, TestTypesF32, TestTypesXF32>::Result;
 
         // Aggregate types <= 64 bit
         using TestTypesLarge = typename Concat<TestTypesMedium, TestTypesF64>::Result;

--- a/test/gemm/gemm_kernel_base.cpp
+++ b/test/gemm/gemm_kernel_base.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -838,9 +838,9 @@ namespace rocwmma
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(bfloat8_t, float32_t, float32_t);
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(bfloat16_t, float32_t, float32_t);
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(float16_t, float32_t, float32_t);
-#if !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#if !ROCWMMA_TESTS_NO_HALF
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(hfloat16_t, float32_t, float32_t);
-#endif // !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#endif // !ROCWMMA_TESTS_NO_HALF
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(float32_t, float32_t, float32_t);
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(xfloat32_t, float32_t, float32_t);
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(float64_t, float64_t, float64_t);
@@ -851,10 +851,10 @@ namespace rocwmma
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(bfloat16_t, bfloat16_t, float32_t);
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(float16_t, float16_t, float16_t);
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(float16_t, float16_t, float32_t);
-#if !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#if !ROCWMMA_TESTS_NO_HALF
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(hfloat16_t, hfloat16_t, hfloat16_t);
     ROCWMMA_INSTANTIATE_GEMM_KERNEL_BASE(hfloat16_t, hfloat16_t, float32_t);
-#endif // !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#endif // !ROCWMMA_TESTS_NO_HALF
 #endif // ROCWMMA_EXTENDED_TESTS
 
 } // namespace rocwmma

--- a/test/gemm/gemm_resource.cpp
+++ b/test/gemm/gemm_resource.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +23,7 @@
  * SOFTWARE.
  *
  *******************************************************************************/
- #include "gemm_resource_impl.hpp"
+#include "gemm_resource_impl.hpp"
 
 namespace rocwmma
 {
@@ -33,9 +33,9 @@ namespace rocwmma
     template struct GemmResource<bfloat8_t, float32_t>;
     template struct GemmResource<bfloat16_t, float32_t>;
     template struct GemmResource<float16_t, float32_t>;
-#if !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#if !ROCWMMA_TESTS_NO_HALF
     template struct GemmResource<hfloat16_t, float32_t>;
-#endif // !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#endif // !ROCWMMA_TESTS_NO_HALF
     template struct GemmResource<float32_t, float32_t>;
     template struct GemmResource<xfloat32_t, float32_t>;
     template struct GemmResource<float64_t, float64_t>;
@@ -44,9 +44,9 @@ namespace rocwmma
     template struct GemmResource<int8_t, int8_t>;
     template struct GemmResource<bfloat16_t, bfloat16_t>;
     template struct GemmResource<float16_t, float16_t>;
-#if !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#if !ROCWMMA_TESTS_NO_HALF
     template struct GemmResource<hfloat16_t, hfloat16_t>;
-#endif // !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#endif // !ROCWMMA_TESTS_NO_HALF
 #endif // ROCWMMA_EXTENDED_TESTS
 
 }

--- a/test/gemm/gemm_test_traits.hpp
+++ b/test/gemm/gemm_test_traits.hpp
@@ -113,11 +113,11 @@ namespace rocwmma
             IsInt8    = std::is_same_v<InputT, int8_t>,
             IsFloat8  = std::is_same_v<InputT, float8_t>,
             IsBFloat8 = std::is_same_v<InputT, bfloat8_t>,
-#if !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#if !ROCWMMA_TESTS_NO_HALF
             IsHFloat16 = std::is_same_v<InputT, hfloat16_t>,
 #else
             IsHFloat16 = false,
-#endif // !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#endif // !ROCWMMA_TESTS_NO_HALF
             IsFloat16  = std::is_same_v<InputT, float16_t> || IsHFloat16,
             IsBFloat16 = std::is_same_v<InputT, bfloat16_t>,
 
@@ -133,11 +133,11 @@ namespace rocwmma
             IsFloat8  = std::is_same_v<OutputT, float8_t>,
             IsBFloat8 = std::is_same_v<OutputT, bfloat8_t>,
 
-#if !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#if !ROCWMMA_TESTS_NO_HALF
             IsHFloat16 = std::is_same_v<OutputT, hfloat16_t>,
 #else
             IsHFloat16 = false,
-#endif // !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#endif // !ROCWMMA_TESTS_NO_HALF
 
             IsFloat16  = std::is_same_v<OutputT, float16_t> || IsHFloat16,
             IsBFloat16 = std::is_same_v<OutputT, bfloat16_t>,
@@ -154,13 +154,13 @@ namespace rocwmma
             IsFloat8  = std::is_same_v<ComputeT, float8_t>,
             IsBFloat8 = std::is_same_v<ComputeT, bfloat8_t>,
 
-#if !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#if !ROCWMMA_TESTS_NO_HALF
             IsHFloat16 = std::is_same_v<ComputeT, hfloat16_t>,
 #else
             IsHFloat16 = false,
-#endif // !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#endif // !ROCWMMA_TESTS_NO_HALF
 
-            IsFloat16 = std::is_same_v<ComputeT, float16_t> || IsHFloat16,
+            IsFloat16  = std::is_same_v<ComputeT, float16_t> || IsHFloat16,
             IsBFloat16 = std::is_same_v<ComputeT, bfloat16_t>,
 
             IsFloat32  = std::is_same_v<ComputeT, float32_t>,

--- a/test/performance.hpp
+++ b/test/performance.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -258,12 +258,12 @@ namespace rocwmma
         };
     };
 
-#if !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#if !ROCWMMA_TESTS_NO_HALF
     template <typename GfxArch>
     struct MfmaPerfTraits<GfxArch, hfloat16_t> : public MfmaPerfTraits<GfxArch, float16_t>
     {
     };
-#endif // !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#endif // !ROCWMMA_TESTS_NO_HALF
 
     template <typename GfxArch, typename DataT>
     struct VALUPerfTraits;
@@ -360,12 +360,12 @@ namespace rocwmma
         };
     };
 
-#if !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#if !ROCWMMA_TESTS_NO_HALF
     template <typename GfxArch>
     struct VALUPerfTraits<GfxArch, hfloat16_t> : public VALUPerfTraits<GfxArch, float16_t>
     {
     };
-#endif // !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#endif // !ROCWMMA_TESTS_NO_HALF
 
     inline double calculateGFlops(uint32_t m, uint32_t n, uint32_t k)
     {

--- a/test/rocblas_reference.hpp
+++ b/test/rocblas_reference.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,16 +28,16 @@
 
 #define ROCM_USE_FLOAT16
 
-#define CHECK_ROCBLAS_ERROR(status)                   \
-    if(status != rocblas_status_success)              \
-    {                                                 \
-        fprintf(stderr,                               \
-                "rocBLAS error: '%s'(%d) at %s:%d\n", \
-                rocblas_status_to_string(status),     \
-                status,                               \
-                __FILE__,                             \
-                __LINE__);                            \
-        exit(EXIT_FAILURE);                           \
+#define CHECK_ROCBLAS_ERROR(expression)                              \
+    if(auto status = (expression); status != rocblas_status_success) \
+    {                                                                \
+        fprintf(stderr,                                              \
+                "rocBLAS error: '%s'(%d) at %s:%d\n",                \
+                rocblas_status_to_string(status),                    \
+                status,                                              \
+                __FILE__,                                            \
+                __LINE__);                                           \
+        exit(EXIT_FAILURE);                                          \
     }
 
 // BETA_FEATURES_API needs to be defined to access the beta features of rocBLAS which includes float8/bfloat8 support.
@@ -170,12 +170,12 @@ namespace rocwmma
         }
     };
 
-#if !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#if !ROCWMMA_TESTS_NO_HALF
     template <>
     struct rocblas_types<hfloat16_t> : public rocblas_types<float16_t>
     {
     };
-#endif // !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#endif // !ROCWMMA_TESTS_NO_HALF
 
     template <>
     struct rocblas_types<bfloat16_t>
@@ -283,10 +283,10 @@ namespace rocwmma
                       ComputeT       alpha,
                       ComputeT       beta)
     {
-        rocblas_datatype a_type       = rocblas_types<InputT>::type();
-        rocblas_datatype b_type       = rocblas_types<InputT>::type();
-        rocblas_datatype c_type       = rocblas_types<OutputT>::type();
-        rocblas_datatype d_type       = rocblas_types<OutputT>::type();
+        rocblas_datatype a_type = rocblas_types<InputT>::type();
+        rocblas_datatype b_type = rocblas_types<InputT>::type();
+        rocblas_datatype c_type = rocblas_types<OutputT>::type();
+        rocblas_datatype d_type = rocblas_types<OutputT>::type();
 
         using a_t = typename rocblas_types<InputT>::DataType;
         using b_t = typename rocblas_types<InputT>::DataType;
@@ -330,35 +330,35 @@ namespace rocwmma
         int32_t  solution_index = 0;
         uint32_t flags          = 0;
 
-        if ((std::is_same<InputT, float8_t>::value) || (std::is_same<InputT, bfloat8_t>::value))
+        if((std::is_same<InputT, float8_t>::value) || (std::is_same<InputT, bfloat8_t>::value))
         {
 #if defined(ROCBLAS_DATA_TYPE_FLOAT8)
             {
-            rocblas_computetype compute_type = rocblas_compute_type_f32;
-            CHECK_ROCBLAS_ERROR(rocblas_gemm_ex3(handle,
-                                                 opA,
-                                                 opB,
-                                                 m,
-                                                 n,
-                                                 k,
-                                                 &alpha,
-                                                 da,
-                                                 a_type,
-                                                 lda,
-                                                 db,
-                                                 b_type,
-                                                 ldb,
-                                                 &beta,
-                                                 dc,
-                                                 c_type,
-                                                 ldc,
-                                                 dd,
-                                                 d_type,
-                                                 ldd,
-                                                 compute_type,
-                                                 algo,
-                                                 solution_index,
-                                                 flags));
+                rocblas_computetype compute_type = rocblas_compute_type_f32;
+                CHECK_ROCBLAS_ERROR(rocblas_gemm_ex3(handle,
+                                                     opA,
+                                                     opB,
+                                                     m,
+                                                     n,
+                                                     k,
+                                                     &alpha,
+                                                     da,
+                                                     a_type,
+                                                     lda,
+                                                     db,
+                                                     b_type,
+                                                     ldb,
+                                                     &beta,
+                                                     dc,
+                                                     c_type,
+                                                     ldc,
+                                                     dd,
+                                                     d_type,
+                                                     ldd,
+                                                     compute_type,
+                                                     algo,
+                                                     solution_index,
+                                                     flags));
             }
 #endif
         }

--- a/test/unit/unit_kernel_base_impl.hpp
+++ b/test/unit/unit_kernel_base_impl.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -80,12 +80,14 @@ namespace rocwmma
     bool UnitKernelBase<BlockM, BlockN, DataT, Layout>::checkDevice() const
     {
         auto deviceArch = DeviceInfo::instance()->getGcnArch();
-        return (deviceArch != DeviceInfo::UNSUPPORTED_ARCH
-                && !(deviceArch == DeviceInfo::GFX908 &&
-                    (std::is_same<DataT, float64_t>::value || std::is_same<DataT, float8_t>::value
-                    || std::is_same<DataT, bfloat8_t>::value))
-                && !(deviceArch == DeviceInfo::GFX90A &&
-                    (std::is_same<DataT, float8_t>::value || std::is_same<DataT, bfloat8_t>::value)));
+        return (
+            deviceArch != DeviceInfo::UNSUPPORTED_ARCH
+            && !(deviceArch == DeviceInfo::GFX908
+                 && (std::is_same<DataT, float64_t>::value || std::is_same<DataT, float8_t>::value
+                     || std::is_same<DataT, bfloat8_t>::value))
+            && !(deviceArch == DeviceInfo::GFX90A
+                 && (std::is_same<DataT, float8_t>::value
+                     || std::is_same<DataT, bfloat8_t>::value)));
     }
 
     template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename Layout>
@@ -123,7 +125,7 @@ namespace rocwmma
         mTBlockX = mTBlockY = 0;
         mM = mN = 0;
         mLd     = 0;
-        mParam1 = mParam2 = DataT(0);
+        mParam1 = mParam2 = rocwmma::convert<DataT>(0);
 
         mRunFlag          = true;
         mValidationResult = false;
@@ -189,8 +191,8 @@ namespace rocwmma
                        static_cast<uint32_t const&>(std::get<1>(problem.threadBlockSize)));
         std::tie(mM, mN) = std::tie(static_cast<uint32_t const&>(std::get<0>(problem.problemSize)),
                                     static_cast<uint32_t const&>(std::get<1>(problem.problemSize)));
-        mParam1          = static_cast<DataT>(problem.param1);
-        mParam2          = static_cast<DataT>(problem.param2);
+        mParam1          = rocwmma::convert<DataT>(problem.param1);
+        mParam2          = rocwmma::convert<DataT>(problem.param2);
         mLd              = std::is_same<Layout, row_major>::value ? mN : mM;
 
         // Clear the kernel to run

--- a/test/unit/unit_test_params.hpp
+++ b/test/unit/unit_test_params.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright 2021-2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2021-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -51,9 +51,9 @@ namespace rocwmma
                                         bfloat8_t,
                                         bfloat16_t,
                                         float16_t,
-#if !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#if !ROCWMMA_TESTS_NO_HALF
                                         hfloat16_t,
-#endif // !(defined(__HIP_NO_HALF_CONVERSIONS__) || defined(HIP_NO_HALF))
+#endif // !ROCWMMA_TESTS_NO_HALF
                                         float32_t,
                                         xfloat32_t,
                                         int8_t,


### PR DESCRIPTION
…with __HIP_NO_HALF_OPERATORS__ in API

Fully respects HIP_NO_HALF, __HIP_NO_HALF_CONVERSIONS__ and __HIP_NO_HALF_OPERATORS__ 

- Two major cases: HIP_NO_HALF = 0, 1
- rocWMMA API and tests now can handle both cases.
- ROCWMMA_NO_HALF gets value 0 or 1 which is set by HIP_NO_HALF

- 4 sub-cases for HIP_NO_HALF = 0:  
-      __HIP_NO_HALF_CONVERSIONS__= 0, 1, __HIP_NO_HALF_OPERATORS__ = 0, 1

- rocWMMA API can handle either __HIP_NO_HALF_CONVERSIONS__ and / or __HIP_NO_HALF_OPERATORS
- rocWMMA tests cancel hfloat16_t tests if __HIP_NO_HALF_CONVERSIONS__ is present. This is due to the large amount of refactoring required in the existing testing infrastructure.

- ROCWMMA_TESTS_NO_HALF controls whether tests will include the hfloat16_t tests

Other fixes:
- Resolve ambiguities seen by the convert function.
- Reorder Incoming / Outgoing params in the convert function to leverage automated lookup in inputs.
- Fix samples CHECK_HIP_ERROR and CHECK_HIPRTC_ERROR macros for expression repetition
- Fix CHECK_RSMI_ERROR macro for expression reptition


